### PR TITLE
feat: restore window state

### DIFF
--- a/docs/api/structures/window-state-restore-options.md
+++ b/docs/api/structures/window-state-restore-options.md
@@ -1,3 +1,5 @@
 # WindowStateRestoreOptions Object
 
 * `stateId` string - A unique identifier used for saving and restoring window state.
+* `bounds` boolean (optional) - Whether to restore window bounds (position and size). Defaults to `true` internally if not specified.
+* `displayMode` boolean (optional) - Whether to restore display modes (fullscreen, kiosk, maximized, etc.). Defaults to `true` internally if not specified.

--- a/spec/api-browser-window-spec.ts
+++ b/spec/api-browser-window-spec.ts
@@ -7211,7 +7211,9 @@ describe('BrowserWindow module', () => {
             width: 400,
             height: 300,
             windowStateRestoreOptions: {
-              stateId
+              stateId,
+              bounds: false,
+              displayMode: false
             }
           });
         });
@@ -7320,6 +7322,202 @@ describe('BrowserWindow module', () => {
           const finalModTime = getPrefsModTime();
 
           expect(finalModTime.getTime()).to.equal(initialModTime.getTime());
+        });
+      });
+    });
+
+    describe('window state restoration', () => {
+      const preferencesPath = path.join(app.getPath('userData'), 'Local State');
+
+      const getPrefsModTime = (): Date => {
+        try {
+          return fs.statSync(preferencesPath).mtime;
+        } catch {
+          throw new Error(`Test requires preferences file to exist at path: ${preferencesPath}.`);
+        }
+      };
+
+      const waitForPrefsUpdate = async (initialModTime: Date, timeoutMs: number = 20000): Promise<void> => {
+        const startTime = Date.now();
+        while (true) {
+          const currentModTime = getPrefsModTime();
+          if (currentModTime > initialModTime) return;
+          if (Date.now() - startTime > timeoutMs) {
+            throw new Error(`Window state was not flushed to disk within ${timeoutMs}ms`);
+          }
+          await setTimeout(1000);
+        }
+      };
+
+      afterEach(closeAllWindows);
+
+      describe('bounds restoration', () => {
+        let w: BrowserWindow;
+        const stateId = 'test-bounds-restore';
+
+        beforeEach(async () => {
+          w = new BrowserWindow({
+            show: false,
+            windowStateRestoreOptions: {
+              stateId
+            }
+          });
+
+          w.setSize(400, 300);
+        });
+
+        it('should restore window position', async () => {
+          const moved = once(w, 'move');
+          w.setPosition(150, 200);
+          await moved;
+
+          const initialModTime = getPrefsModTime();
+          w.close();
+          await waitForPrefsUpdate(initialModTime);
+
+          w = new BrowserWindow({
+            show: false,
+            windowStateRestoreOptions: {
+              stateId,
+              bounds: true,
+              displayMode: false
+            }
+          });
+
+          const [x, y] = w.getPosition();
+          expect(x).to.equal(150);
+          expect(y).to.equal(200);
+        });
+
+        it('should restore window size', async () => {
+          const resized = once(w, 'resize');
+          w.setSize(500, 400);
+          await resized;
+
+          const initialModTime = getPrefsModTime();
+          w.close();
+          await waitForPrefsUpdate(initialModTime);
+
+          w = new BrowserWindow({
+            show: false,
+            windowStateRestoreOptions: {
+              stateId,
+              bounds: true,
+              displayMode: false
+            }
+          });
+
+          const [width, height] = w.getSize();
+          expect(width).to.equal(500);
+          expect(height).to.equal(400);
+        });
+
+        it('should restore both position and size', async () => {
+          const moved = once(w, 'move');
+          w.setPosition(100, 150);
+          await moved;
+
+          const resized = once(w, 'resize');
+          w.setSize(600, 450);
+          await resized;
+
+          const initialModTime = getPrefsModTime();
+          w.close();
+          await waitForPrefsUpdate(initialModTime);
+
+          w = new BrowserWindow({
+            show: false,
+            windowStateRestoreOptions: {
+              stateId,
+              bounds: true,
+              displayMode: false
+            }
+          });
+
+          const [x, y] = w.getPosition();
+          const [width, height] = w.getSize();
+          expect(x).to.equal(100);
+          expect(y).to.equal(150);
+          expect(width).to.equal(600);
+          expect(height).to.equal(450);
+        });
+      });
+
+      describe('display mode restoration', () => {
+        let w: BrowserWindow;
+        const stateId = 'test-display-restore';
+
+        beforeEach(async () => {
+          w = new BrowserWindow({
+            show: false,
+            width: 400,
+            height: 300,
+            windowStateRestoreOptions: {
+              stateId,
+              displayMode: false
+            }
+          });
+        });
+
+        it('should restore maximized state', async () => {
+          const maximized = once(w, 'maximize');
+          w.maximize();
+          await maximized;
+
+          const initialModTime = getPrefsModTime();
+          w.close();
+          await waitForPrefsUpdate(initialModTime);
+
+          w = new BrowserWindow({
+            show: false,
+            windowStateRestoreOptions: {
+              stateId,
+              bounds: false,
+              displayMode: true
+            }
+          });
+
+          expect(w.isMaximized()).to.equal(true);
+        });
+
+        it('should restore fullscreen state', async () => {
+          w.setFullScreen(true);
+          await setTimeout(1000);
+
+          const initialModTime = getPrefsModTime();
+          w.close();
+          await waitForPrefsUpdate(initialModTime);
+
+          w = new BrowserWindow({
+            show: false,
+            windowStateRestoreOptions: {
+              stateId,
+              bounds: false,
+              displayMode: true
+            }
+          });
+
+          expect(w.isFullScreen()).to.equal(true);
+        });
+
+        it('should restore kiosk state', async () => {
+          w.setKiosk(true);
+          await setTimeout(1000);
+
+          const initialModTime = getPrefsModTime();
+          w.close();
+          await waitForPrefsUpdate(initialModTime);
+
+          w = new BrowserWindow({
+            show: false,
+            windowStateRestoreOptions: {
+              stateId,
+              bounds: false,
+              displayMode: true
+            }
+          });
+
+          expect(w.isKiosk()).to.equal(true);
         });
       });
     });


### PR DESCRIPTION
#### Description of Change
> [!NOTE]
> This PR is part of GSoC 2025 [project](https://electronhq.notion.site/Electron-Google-Summer-of-Code-2025-Ideas-List-1851459d1bd1811894dad8b48a68596d#1851459d1bd18153b559ca297694dda2). 

Restores window state (bounds and display mode) from values set in https://github.com/electron/electron/pull/47425/file. Edge cases are handled similar to Chromium's `WindowSizer::AdjustBoundsToBeVisibleOnDisplay` https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/window_sizer/window_sizer.cc;l=368;drc=0ec56065ba588552f21633aa47280ba02c3cd160#:~:text=349-,350,-351

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [x] relevant API documentation, tutorials, and examples are updated and follow the [documentation style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md)

#### Release Notes

Notes: none